### PR TITLE
feat: add capacity fields to posiciones entity

### DIFF
--- a/requests/posiciones.rest
+++ b/requests/posiciones.rest
@@ -13,11 +13,25 @@ Authorization: {{credenciales}}
 POST {{pathUrl}}/posiciones/newOne/P-03
 Authorization: {{credenciales}}
 
-### Eliminar una posicion 
+### Eliminar una posicion
 DELETE {{pathUrl}}/posicion/deleteOneById/3729
 Authorization: {{credenciales}}
 
 ### Obtiene todas las posiciones
 GET {{pathUrl}}/posiciones/getAll
 Authorization: {{credenciales}}
+
+### Actualiza una posición existente
+PUT {{pathUrl}}/posiciones/1769
+Authorization: {{credenciales}}
+Content-Type: application/json
+
+{
+  "UsuarioInventario": "Leo Lob",
+  "FechaInventario": "2021-07-01",
+  "CapacidadPesoKg": 1000,
+  "CapacidadVolumenCm3": 500000,
+  "FactorDesperdicio": 0.1,
+  "CategoriaPermitidaId": 1
+}
 

--- a/src/entities/Posicion.ts
+++ b/src/entities/Posicion.ts
@@ -14,4 +14,16 @@ export class Posicion {
 
     @Column({name: "usuario_inventario"})
     UsuarioInventario: string
+
+    @Column({name: "capacidad_peso_kg", type: "float", nullable: true})
+    CapacidadPesoKg: number
+
+    @Column({name: "capacidad_volumen_cm3", type: "float", nullable: true})
+    CapacidadVolumenCm3: number
+
+    @Column({name: "factor_desperdicio", type: "float", nullable: true})
+    FactorDesperdicio: number
+
+    @Column({name: "categoria_permitida_id", type: "int", nullable: true})
+    CategoriaPermitidaId: number
 }

--- a/src/migrations/172-add-capacity-fields-posiciones.ts
+++ b/src/migrations/172-add-capacity-fields-posiciones.ts
@@ -1,0 +1,48 @@
+import { MigrationInterface, QueryRunner, TableColumn } from "typeorm";
+
+export class AddCapacityFieldsPosiciones172 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.addColumn(
+            "posiciones",
+            new TableColumn({
+                name: "capacidad_peso_kg",
+                type: "float",
+                isNullable: true,
+            })
+        );
+
+        await queryRunner.addColumn(
+            "posiciones",
+            new TableColumn({
+                name: "capacidad_volumen_cm3",
+                type: "float",
+                isNullable: true,
+            })
+        );
+
+        await queryRunner.addColumn(
+            "posiciones",
+            new TableColumn({
+                name: "factor_desperdicio",
+                type: "float",
+                isNullable: true,
+            })
+        );
+
+        await queryRunner.addColumn(
+            "posiciones",
+            new TableColumn({
+                name: "categoria_permitida_id",
+                type: "int",
+                isNullable: true,
+            })
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropColumn("posiciones", "categoria_permitida_id");
+        await queryRunner.dropColumn("posiciones", "factor_desperdicio");
+        await queryRunner.dropColumn("posiciones", "capacidad_volumen_cm3");
+        await queryRunner.dropColumn("posiciones", "capacidad_peso_kg");
+    }
+}


### PR DESCRIPTION
## Summary
- extend Posicion entity with capacity, volume, waste factor and category fields
- add migration altering `posiciones` table with new columns
- update sample requests with new fields for seeding/initial data

## Testing
- `npm run test:pdf` *(fails: Cannot find module './remitoPdf.test.ts')*
- `npm run build` *(fails: xcopy: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6671eae64832abe04ef01fca5afa3