### PR TITLE
feat: handle position capacity and category fields

### DIFF
--- a/src/DALC/posiciones.dalc.ts
+++ b/src/DALC/posiciones.dalc.ts
@@ -5,8 +5,20 @@ import {PosicionProducto} from "../entities/PosicionProducto"
 import {HistoricoPosiciones} from "../entities/HistoricoPosiciones"
 import { producto_getPosiciones_byIdProducto_DALC, producto_moverDePosicion_DALC } from "./productos.dalc"
 
-export const posicion_add = async (nombre: string) => {
-    const resultToSave = getRepository(Posicion).create({Nombre: nombre})
+export const posicion_add = async (
+    nombre: string,
+    capacidadPeso?: number,
+    capacidadVolumen?: number,
+    factorDesperdicio?: number,
+    categoriaPermitidaId?: number
+  ) => {
+    const resultToSave = getRepository(Posicion).create({
+        Nombre: nombre,
+        CapacidadPesoKg: capacidadPeso,
+        CapacidadVolumenCm3: capacidadVolumen,
+        FactorDesperdicio: factorDesperdicio,
+        CategoriaPermitidaId: categoriaPermitidaId
+    })
     try {
         const result = await getRepository(Posicion).save(resultToSave)
         return {status: true, detalle: result}
@@ -18,7 +30,7 @@ export const posicion_add = async (nombre: string) => {
     }
   }
 
-export const posicion_modify = async (id: number, body: object) => {
+export const posicion_modify = async (id: number, body: Partial<Posicion>) => {
     const posicionActual=await getRepository(Posicion).findOne(id)
     if (posicionActual!=null) {
         getRepository(Posicion).merge(posicionActual, body)

--- a/src/routes/posiciones.routes.ts
+++ b/src/routes/posiciones.routes.ts
@@ -47,7 +47,7 @@ router.get(prefixAPI+"/posiciones/getDetallePosicionByIdYEmpresa/:idProducto/:id
 router.get(prefixAPI + "/posiciones/getAllByEmpresaConDetalle/:idEmpresa", getPosicionesConDetalleByEmpresa)
 router.get(prefixAPI + "/posiciones/getAllByEmpresaConProductos/:idEmpresa", getAllByEmpresaConProductos);
 
-router.post(prefixAPI+"/posiciones/newOne/:nombre", newPosicion)
+router.post(prefixAPI+"/posiciones/newOne", newPosicion)
 
 router.put(prefixAPI+"/posiciones/:id", setPosicion)
 


### PR DESCRIPTION
## Summary
- allow creating and updating positions with capacity, waste and category fields
- validate non-negative values and ensure category exists
- persist new capacity fields in DALC layer

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: xcopy not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b66a1d2b5c832a810ff17ca9c681fe