### PR TITLE
feat: add occupancy endpoint for positions

### DIFF
--- a/src/controllers/posiciones.controller.ts
+++ b/src/controllers/posiciones.controller.ts
@@ -17,6 +17,7 @@ import {
     detallePosicion_getByIdProd_DALC,
     fechaPos_edit_DALC,
     posicion_getContent_ByIdProducto_DALC,
+    posicion_getOcupacion_DALC,
     getAllPosicionesByIdEmpresa_DALC,
     posiciones_getByIdProdAndLote_DALC,
     posiciones_getByLote_DALC,
@@ -171,6 +172,38 @@ export const getContentByID = async (req: Request, res: Response): Promise <Resp
         return res.json(require("lsi-util-node/API").getFormatedResponse("", "Id Posición inexistente"))
     }
     return res.json(require("lsi-util-node/API").getFormatedResponse(results))
+}
+
+export const getOcupacionById = async (req: Request, res: Response): Promise<Response> => {
+    try {
+        const idPosicion = Number(req.params.id)
+        if (isNaN(idPosicion)) {
+            return res.status(400).json(
+                require("lsi-util-node/API").getFormatedResponse("", "Parámetro id inválido")
+            )
+        }
+
+        const idEmpresa = req.query.empresa
+            ? Number(req.query.empresa)
+            : undefined
+        const zona = req.query.zona ? String(req.query.zona) : undefined
+
+        const ocupacion = await posicion_getOcupacion_DALC(idPosicion, {
+            idEmpresa,
+            zona,
+        })
+
+        return res.json(
+            require("lsi-util-node/API").getFormatedResponse(ocupacion)
+        )
+    } catch (err: any) {
+        return res.status(500).json(
+            require("lsi-util-node/API").getFormatedResponse(
+                "",
+                err.message || "Error interno"
+            )
+        )
+    }
 }
 
 export const getAllPosicionesByIdEmpresa = async (req: Request, res: Response): Promise <Response> => {

--- a/src/routes/posiciones.routes.ts
+++ b/src/routes/posiciones.routes.ts
@@ -22,8 +22,9 @@ import {
     getPosicionesByIdProductoAndLote,
     getPosicionesByLote,
     getPosicionesByLoteDetalle,
-    getPosicionesConDetalleByEmpresa, 
-    getAllByEmpresaConProductos
+    getPosicionesConDetalleByEmpresa,
+    getAllByEmpresaConProductos,
+    getOcupacionById
 } from "../controllers/posiciones.controller"
 
 const prefixAPI="/apiv3"
@@ -34,6 +35,7 @@ router.get(prefixAPI+"/posiciones/byNombre/:nombre", getPosicionesPorNombre)
 router.get(prefixAPI+"/posiciones/byId/:id", getByID)
 router.put(prefixAPI+"/posiciones/vaciar/:id", vaciarPosicion)
 router.get(prefixAPI+"/posiciones/getContentById/:id", getContentByID)
+router.get(prefixAPI+"/posiciones/:id/ocupacion", getOcupacionById)
 router.get(prefixAPI+"/posiciones/getAllPosicionesByIdEmpresa/:idEmpresa", getAllPosicionesByIdEmpresa)
 router.get(prefixAPI+"/ordenes/detallePosicionAndProductoByIdProducto/:idProducto", getDetallePosicionesProductoByIdProducto)
 router.get(prefixAPI+"/posiciones/conPosicionadoNegativo", getPosicionesConPosicionadoNegativo)


### PR DESCRIPTION
## Summary
- add DALC method to calculate occupied weight and volume in a position
- expose GET /apiv3/posiciones/:id/ocupacion with optional empresa or zona filters

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run test:pdf` *(fails: Cannot find module './remitoPdf.test.ts')*

------
https://chatgpt.com/codex/tasks/task_e_68b66d3bf260832a97bba40b7915a05f