### PR TITLE
feat: add pallet entities and capacity validation

### DIFF
--- a/src/controllers/productos.controller.ts
+++ b/src/controllers/productos.controller.ts
@@ -87,7 +87,8 @@ export const set_posicionar = async (req: Request, res: Response): Promise <Resp
         }
     }
 
-    const result=await producto_posicionar_DALC(producto!, posicion!, parseInt(req.params.cantidadAPosicionar),parseInt(req.params.idEmpresa))
+    const idPallet = req.body?.idPallet ? parseInt(req.body.idPallet) : undefined
+    const result=await producto_posicionar_DALC(producto!, posicion!, parseInt(req.params.cantidadAPosicionar),parseInt(req.params.idEmpresa), idPallet)
 
     if (result.status==="OK") {
         return res.json(require("lsi-util-node/API").getFormatedResponse("OK"))
@@ -133,7 +134,8 @@ export const set_posicionar_excel = async (req: Request, res: Response): Promise
     if (producto===null) {
         return res.status(404).json(require("lsi-util-node/API").getFormatedResponse("", "Producto inexistente"))
     }
-    const result=await reposicionar_producto_excel_DALC(producto!, posicion!, parseInt(req.params.cantidadAPosicionar),req.params.usuario)
+    const idPallet = req.body?.idPallet ? parseInt(req.body.idPallet) : undefined
+    const result=await reposicionar_producto_excel_DALC(producto!, posicion!, parseInt(req.params.cantidadAPosicionar),req.params.usuario, idPallet)
 
     if (result.status==="OK") {
         return res.json(require("lsi-util-node/API").getFormatedResponse("OK"))

--- a/src/entities/Pallet.ts
+++ b/src/entities/Pallet.ts
@@ -1,0 +1,38 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn } from "typeorm";
+import { PalletTipo } from "./PalletTipo";
+import { Posicion } from "./Posicion";
+
+@Entity("pallets")
+export class Pallet {
+    @PrimaryGeneratedColumn({ name: "id" })
+    Id: number;
+
+    @Column({ name: "codigo" })
+    Codigo: string;
+
+    @Column({ name: "pallet_tipo_id" })
+    PalletTipoId: number;
+
+    @ManyToOne(() => PalletTipo, tipo => tipo.Pallets)
+    @JoinColumn({ name: "pallet_tipo_id" })
+    Tipo: PalletTipo;
+
+    @Column({ name: "posicion_id", nullable: true })
+    PosicionId: number;
+
+    @ManyToOne(() => Posicion, posicion => posicion.Pallets, { nullable: true })
+    @JoinColumn({ name: "posicion_id" })
+    Posicion?: Posicion;
+
+    @Column({ name: "volumen_ocupado_cm3", type: "float", default: 0 })
+    VolumenOcupadoCm3: number;
+
+    @Column({ name: "peso_ocupado_kg", type: "float", default: 0 })
+    PesoOcupadoKg: number;
+
+    @Column({ name: "espacio_libre_volumen_cm3", type: "float", default: 0 })
+    EspacioLibreVolumenCm3: number;
+
+    @Column({ name: "espacio_libre_peso_kg", type: "float", default: 0 })
+    EspacioLibrePesoKg: number;
+}

--- a/src/entities/PalletTipo.ts
+++ b/src/entities/PalletTipo.ts
@@ -1,0 +1,20 @@
+import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from "typeorm";
+import { Pallet } from "./Pallet";
+
+@Entity("pallet_tipos")
+export class PalletTipo {
+    @PrimaryGeneratedColumn({ name: "id" })
+    Id: number;
+
+    @Column({ name: "nombre" })
+    Nombre: string;
+
+    @Column({ name: "capacidad_peso_kg", type: "float" })
+    CapacidadPesoKg: number;
+
+    @Column({ name: "capacidad_volumen_cm3", type: "float" })
+    CapacidadVolumenCm3: number;
+
+    @OneToMany(() => Pallet, pallet => pallet.Tipo)
+    Pallets: Pallet[];
+}

--- a/src/entities/Posicion.ts
+++ b/src/entities/Posicion.ts
@@ -1,5 +1,6 @@
-import {Entity, Column, PrimaryGeneratedColumn, ManyToOne, JoinColumn} from "typeorm"
+import {Entity, Column, PrimaryGeneratedColumn, ManyToOne, JoinColumn, OneToMany} from "typeorm"
 import { Categoria } from "./Categoria"
+import { Pallet } from "./Pallet"
 
 @Entity("posiciones")
 
@@ -31,4 +32,7 @@ export class Posicion {
     @ManyToOne(() => Categoria, categoria => categoria.Posiciones, {nullable: true})
     @JoinColumn({name: "categoria_permitida_id"})
     CategoriaPermitida?: Categoria
+
+    @OneToMany(() => Pallet, pallet => pallet.Posicion)
+    Pallets?: Pallet[]
 }

--- a/src/migrations/175-create-pallet-tables.ts
+++ b/src/migrations/175-create-pallet-tables.ts
@@ -1,0 +1,48 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey } from "typeorm";
+
+export class CreatePalletTables175 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(new Table({
+            name: "pallet_tipos",
+            columns: [
+                { name: "id", type: "int", isPrimary: true, isGenerated: true, generationStrategy: "increment" },
+                { name: "nombre", type: "varchar", length: "100" },
+                { name: "capacidad_peso_kg", type: "float" },
+                { name: "capacidad_volumen_cm3", type: "float" }
+            ]
+        }));
+
+        await queryRunner.createTable(new Table({
+            name: "pallets",
+            columns: [
+                { name: "id", type: "int", isPrimary: true, isGenerated: true, generationStrategy: "increment" },
+                { name: "codigo", type: "varchar", length: "50" },
+                { name: "pallet_tipo_id", type: "int" },
+                { name: "posicion_id", type: "int", isNullable: true },
+                { name: "volumen_ocupado_cm3", type: "float", default: 0 },
+                { name: "peso_ocupado_kg", type: "float", default: 0 },
+                { name: "espacio_libre_volumen_cm3", type: "float", default: 0 },
+                { name: "espacio_libre_peso_kg", type: "float", default: 0 }
+            ]
+        }));
+
+        await queryRunner.createForeignKey("pallets", new TableForeignKey({
+            columnNames: ["pallet_tipo_id"],
+            referencedTableName: "pallet_tipos",
+            referencedColumnNames: ["id"],
+            onDelete: "CASCADE"
+        }));
+
+        await queryRunner.createForeignKey("pallets", new TableForeignKey({
+            columnNames: ["posicion_id"],
+            referencedTableName: "posiciones",
+            referencedColumnNames: ["id"],
+            onDelete: "SET NULL"
+        }));
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable("pallets");
+        await queryRunner.dropTable("pallet_tipos");
+    }
+}


### PR DESCRIPTION
## Summary
- add pallet and pallet type entities with migration
- validate pallet and position capacities during positioning
- track free space per pallet for efficiency

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: xcopy not found)
- `npx tsc`


------
https://chatgpt.com/codex/tasks/task_e_68b747915ab0832a9ce221857ed021b2