### PR TITLE
feat: add position monitoring and dashboard

### DIFF
--- a/src/controllers/dashboard.controller.ts
+++ b/src/controllers/dashboard.controller.ts
@@ -1,0 +1,52 @@
+import { Request, Response } from "express";
+import { getRepository } from "typeorm";
+import { Posicion } from "../entities/Posicion";
+import { PosicionMetrica } from "../entities/PosicionMetrica";
+import { EmpresaConfiguracion } from "../entities/EmpresaConfiguracion";
+import { posicion_getOcupacion_DALC } from "../DALC/posiciones.dalc";
+
+export const getDashboard = async (req: Request, res: Response): Promise<Response> => {
+    const api = require('lsi-util-node/API');
+    const idEmpresa = Number(req.params.idEmpresa);
+    const zona = req.query.zona ? String(req.query.zona) : undefined;
+
+    if (isNaN(idEmpresa)) {
+        return res.status(400).json(api.getFormatedResponse('', 'Parámetro inválido'));
+    }
+
+    const posiciones = await getRepository(Posicion).find();
+    const config = await getRepository(EmpresaConfiguracion).findOne({ where: { IdEmpresa: idEmpresa } as any });
+    const umbralOcup = config?.UmbralOcupacion ?? 0;
+    const umbralPeso = config?.UmbralSobrepeso ?? 0;
+
+    let totalPct = 0;
+    let count = 0;
+    const criticas: any[] = [];
+
+    for (const pos of posiciones) {
+        const ocup = await posicion_getOcupacion_DALC(pos.Id, { idEmpresa, zona });
+        const pct = pos.CapacidadVolumenCm3 ? ocup.VolumenOcupadoCm3 / pos.CapacidadVolumenCm3 : 0;
+        totalPct += pct;
+        count++;
+        const pctPeso = pos.CapacidadPesoKg ? ocup.PesoOcupadoKg / pos.CapacidadPesoKg : 0;
+        if ((umbralOcup && pct > umbralOcup) || (umbralPeso && pctPeso > umbralPeso)) {
+            criticas.push({ Id: pos.Id, Nombre: pos.Nombre, Ocupacion: pct });
+        }
+    }
+
+    const rotacionRows = await getRepository(PosicionMetrica)
+        .createQueryBuilder('pm')
+        .select('pm.posicionId', 'posicionId')
+        .addSelect('SUM(pm.unidades)', 'mov')
+        .where('pm.empresaId = :idEmpresa', { idEmpresa })
+        .groupBy('pm.posicionId')
+        .getRawMany();
+    const rotacionPromedio = rotacionRows.reduce((a, r) => a + Number(r.mov), 0) / (rotacionRows.length || 1);
+
+    const data = {
+        ocupacionPromedio: count ? totalPct / count : 0,
+        rotacionPromedio,
+        posicionesCriticas: criticas
+    };
+    return res.json(api.getFormatedResponse(data));
+};

--- a/src/entities/EmpresaConfiguracion.ts
+++ b/src/entities/EmpresaConfiguracion.ts
@@ -189,4 +189,12 @@ export class EmpresaConfiguracion {
     @Column({name: "contacto_deposito"})
     ContactoDeposito: string
 
+    @Column({name: "umbral_ocupacion", type: "float", nullable: true})
+    UmbralOcupacion?: number
+
+    @Column({name: "umbral_sobrepeso", type: "float", nullable: true})
+    UmbralSobrepeso?: number
+
+    @Column({name: "umbral_falta_stock", type: "int", nullable: true})
+    UmbralFaltaStock?: number
 }

--- a/src/entities/Zona.ts
+++ b/src/entities/Zona.ts
@@ -10,4 +10,12 @@ export class Zona {
 
     @Column({name: "color", nullable: true})
     Color?: string;
+    @Column({name: "umbral_ocupacion", type: "float", nullable: true})
+    UmbralOcupacion?: number;
+
+    @Column({name: "umbral_sobrepeso", type: "float", nullable: true})
+    UmbralSobrepeso?: number;
+
+    @Column({name: "umbral_falta_stock", type: "int", nullable: true})
+    UmbralFaltaStock?: number;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,8 @@ import emailTemplatesRoutes from './routes/emailTemplates.routes';
 import emailProcesoConfigRoutes from './routes/emailProcesoConfig.routes';
 import reportesRoutes from './routes/reportes.routes';
 import zonasRoutes from './routes/zonas.routes';
+import dashboardRoutes from './routes/dashboard.routes';
+import { monitorService } from './services/monitor.service';
 
 import tiendaNubeRoutes from "./api/tiendanube/routes/tiendanube.routes";
 import yiqiRoutes from "./api/yiqi/routes/yiqi.routes";
@@ -92,6 +94,7 @@ app.use(emailProcesoConfigRoutes)
 app.use(auditoriaRoutes)
 app.use(reportesRoutes)
 app.use(zonasRoutes)
+app.use(dashboardRoutes)
 
 
 // Rutas de Integraciones con APIS
@@ -111,6 +114,7 @@ if (config.env==="D") {
         }
         console.log("Sirviendo en el puerto:",config.puerto, " - Base de datos:", config.database==="P" ? 'Productiva' : 'Desarrollo')
         swaggerDocs(app, config.puerto)
+        monitorService.start()
     })
 } else {
     const httpsServerOptions={
@@ -122,6 +126,7 @@ if (config.env==="D") {
     https.createServer(httpsServerOptions, app).listen(config.puerto, async () => {
         await conectaProduccionUniversal()
         console.log("HTTPS Sirviendo en el puerto "+config.puerto)
+        monitorService.start()
     })
 
 }

--- a/src/migrations/175-add-alerta-config.ts
+++ b/src/migrations/175-add-alerta-config.ts
@@ -1,0 +1,25 @@
+import {MigrationInterface, QueryRunner, TableColumn} from "typeorm";
+
+export class addAlertaConfig175 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.addColumns("empresas_configuracion", [
+            new TableColumn({ name: "umbral_ocupacion", type: "float", isNullable: true }),
+            new TableColumn({ name: "umbral_sobrepeso", type: "float", isNullable: true }),
+            new TableColumn({ name: "umbral_falta_stock", type: "int", isNullable: true })
+        ]);
+        await queryRunner.addColumns("zonas", [
+            new TableColumn({ name: "umbral_ocupacion", type: "float", isNullable: true }),
+            new TableColumn({ name: "umbral_sobrepeso", type: "float", isNullable: true }),
+            new TableColumn({ name: "umbral_falta_stock", type: "int", isNullable: true })
+        ]);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropColumn("empresas_configuracion", "umbral_ocupacion");
+        await queryRunner.dropColumn("empresas_configuracion", "umbral_sobrepeso");
+        await queryRunner.dropColumn("empresas_configuracion", "umbral_falta_stock");
+        await queryRunner.dropColumn("zonas", "umbral_ocupacion");
+        await queryRunner.dropColumn("zonas", "umbral_sobrepeso");
+        await queryRunner.dropColumn("zonas", "umbral_falta_stock");
+    }
+}

--- a/src/routes/dashboard.routes.ts
+++ b/src/routes/dashboard.routes.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+import { getDashboard } from "../controllers/dashboard.controller";
+
+const router = Router();
+const prefixAPI = "/apiv3";
+
+router.get(prefixAPI + "/dashboard/:idEmpresa", getDashboard);
+
+export default router;

--- a/src/services/monitor.service.ts
+++ b/src/services/monitor.service.ts
@@ -1,0 +1,58 @@
+import { getRepository } from "typeorm";
+import { Posicion } from "../entities/Posicion";
+import { PosicionMetrica } from "../entities/PosicionMetrica";
+import { EmpresaConfiguracion } from "../entities/EmpresaConfiguracion";
+import { posicion_getOcupacion_DALC } from "../DALC/posiciones.dalc";
+import { emailService } from "./email.service";
+
+export class MonitorService {
+    private timer?: NodeJS.Timer;
+
+    public start(intervalMs = 300000) {
+        if (!this.timer) {
+            this.timer = setInterval(() => this.checkAll(), intervalMs);
+        }
+    }
+
+    private async checkAll() {
+        const configs = await getRepository(EmpresaConfiguracion).find();
+        for (const cfg of configs) {
+            await this.checkEmpresa(cfg);
+        }
+    }
+
+    private async checkEmpresa(cfg: EmpresaConfiguracion) {
+        const posiciones = await getRepository(Posicion).find();
+        for (const pos of posiciones) {
+            const ocupacion = await posicion_getOcupacion_DALC(pos.Id, { idEmpresa: cfg.IdEmpresa });
+            const pctVol = pos.CapacidadVolumenCm3 ? ocupacion.VolumenOcupadoCm3 / pos.CapacidadVolumenCm3 : 0;
+            const pctPeso = pos.CapacidadPesoKg ? ocupacion.PesoOcupadoKg / pos.CapacidadPesoKg : 0;
+
+            if (
+                (cfg.UmbralOcupacion && pctVol > cfg.UmbralOcupacion) ||
+                (cfg.UmbralSobrepeso && pctPeso > cfg.UmbralSobrepeso) ||
+                (cfg.UmbralFaltaStock && await this.faltaStock(pos.Id, cfg.IdEmpresa, cfg.UmbralFaltaStock))
+            ) {
+                await emailService.sendEmail({
+                    idEmpresa: cfg.IdEmpresa,
+                    destinatarios: cfg.ContactoDeposito || "alertas@example.com",
+                    titulo: "Alerta de posición",
+                    cuerpo: `La posición ${pos.Nombre} superó los límites configurados.`
+                });
+            }
+        }
+    }
+
+    private async faltaStock(idPosicion: number, idEmpresa: number, umbral: number): Promise<boolean> {
+        const row = await getRepository(PosicionMetrica)
+            .createQueryBuilder("pm")
+            .select("SUM(pm.unidades)", "u")
+            .where("pm.posicionId = :idPosicion", { idPosicion })
+            .andWhere("pm.empresaId = :idEmpresa", { idEmpresa })
+            .getRawOne();
+        const unidades = Number(row?.u || 0);
+        return unidades < umbral;
+    }
+}
+
+export const monitorService = new MonitorService();


### PR DESCRIPTION
## Summary
- add threshold columns for occupancy and stock rules
- introduce monitor service to alert when thresholds exceeded
- expose dashboard endpoint with basic warehouse indicators

## Testing
- `npm test` (fails: Missing script)
- `npm run build` (hangs: xcopy not available)


------
https://chatgpt.com/codex/tasks/task_e_68b74941bc64832ab1a4958cc588079c