### PR TITLE
feat: add categorias module

### DIFF
--- a/src/DALC/categorias.dalc.ts
+++ b/src/DALC/categorias.dalc.ts
@@ -1,0 +1,32 @@
+import { getRepository } from "typeorm";
+import { Categoria } from "../entities/Categoria";
+
+export const categorias_getAll_DALC = async () => {
+    return await getRepository(Categoria).find();
+};
+
+export const categoria_getById_DALC = async (id: number) => {
+    return await getRepository(Categoria).findOne({ where: { Id: id } });
+};
+
+export const categoria_add_DALC = async (body: Partial<Categoria>) => {
+    const repo = getRepository(Categoria);
+    const nueva = repo.create(body);
+    return await repo.save(nueva);
+};
+
+export const categoria_edit_DALC = async (body: Partial<Categoria>, id: number) => {
+    const repo = getRepository(Categoria);
+    await repo.update(id, body);
+    return await repo.findOne({ where: { Id: id } });
+};
+
+export const categoria_deleteById_DALC = async (id: number) => {
+    await getRepository(Categoria)
+        .createQueryBuilder()
+        .delete()
+        .from("categorias")
+        .where("Id = :id", { id })
+        .execute();
+    return;
+};

--- a/src/controllers/categorias.controller.ts
+++ b/src/controllers/categorias.controller.ts
@@ -1,0 +1,46 @@
+import { Request, Response } from "express";
+import {
+    categorias_getAll_DALC,
+    categoria_getById_DALC,
+    categoria_add_DALC,
+    categoria_edit_DALC,
+    categoria_deleteById_DALC
+} from "../DALC/categorias.dalc";
+
+export const getAll = async (req: Request, res: Response): Promise<Response> => {
+    const categorias = await categorias_getAll_DALC();
+    if (categorias != null) {
+        return res.json(require("lsi-util-node/API").getFormatedResponse(categorias));
+    } else {
+        return res.status(404).json(require("lsi-util-node/API").getFormatedResponse("", "Error al obtener Categorías"));
+    }
+};
+
+export const getById = async (req: Request, res: Response): Promise<Response> => {
+    const result = await categoria_getById_DALC(parseInt(req.params.id));
+    if (result) {
+        return res.json(require("lsi-util-node/API").getFormatedResponse(result));
+    } else {
+        return res.status(404).json(require("lsi-util-node/API").getFormatedResponse("", "Categoría inexistente"));
+    }
+};
+
+export const create = async (req: Request, res: Response): Promise<Response> => {
+    const result = await categoria_add_DALC(req.body);
+    return res.json(require("lsi-util-node/API").getFormatedResponse(result));
+};
+
+export const update = async (req: Request, res: Response): Promise<Response> => {
+    const idCategoria = parseInt(req.params.id);
+    const categoria = await categoria_getById_DALC(idCategoria);
+    if (categoria) {
+        const result = await categoria_edit_DALC(req.body, idCategoria);
+        return res.json(require("lsi-util-node/API").getFormatedResponse(result));
+    }
+    return res.status(404).json(require("lsi-util-node/API").getFormatedResponse("", "Categoría inexistente"));
+};
+
+export const remove = async (req: Request, res: Response): Promise<Response> => {
+    await categoria_deleteById_DALC(parseInt(req.params.id));
+    return res.json(require("lsi-util-node/API").getFormatedResponse("OK"));
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import guiasRoutes from './routes/guias.routes'
 import guiasRendicionesRoutes from './routes/guiasRendiciones.routes'
 import posicionesRoutes from './routes/posiciones.routes'
 import productosRoutes from './routes/productos.routes'
+import categoriasRoutes from './routes/categorias.routes'
 import posicionesProductosRoutes from './routes/posicionesProductos.routes'
 import ordenesRoutes from './routes/ordenes.routes'
 import chofereRoutes from './routes/choferes.routes'
@@ -76,6 +77,7 @@ app.use(guiasRoutes)
 app.use(guiasRendicionesRoutes)
 app.use(posicionesRoutes)
 app.use(productosRoutes)
+app.use(categoriasRoutes)
 app.use(posicionesProductosRoutes)
 app.use(ordenesRoutes)
 app.use(chofereRoutes)

--- a/src/migrations/176-create-categorias.ts
+++ b/src/migrations/176-create-categorias.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner, Table } from "typeorm";
+
+export class CreateCategorias176 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(new Table({
+            name: "categorias",
+            columns: [
+                { name: "Id", type: "int", isPrimary: true, isGenerated: true, generationStrategy: "increment" },
+                { name: "descripcion", type: "varchar", length: "100" }
+            ]
+        }));
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable("categorias");
+    }
+}

--- a/src/routes/categorias.routes.ts
+++ b/src/routes/categorias.routes.ts
@@ -1,0 +1,13 @@
+import { Router } from "express";
+import { getAll, getById, create, update, remove } from "../controllers/categorias.controller";
+
+const router = Router();
+const prefixAPI = "/apiv3";
+
+router.get(prefixAPI + "/categorias", getAll);
+router.get(prefixAPI + "/categorias/:id", getById);
+router.post(prefixAPI + "/categorias", create);
+router.put(prefixAPI + "/categorias/:id", update);
+router.delete(prefixAPI + "/categorias/:id", remove);
+
+export default router;


### PR DESCRIPTION
## Summary
- add migration for categorias table
- implement DALC, controller, and routes for categorias CRUD
- register categorias routes in app

## Testing
- `npm test` (fails: Missing script "test")
- `npm run test:pdf` (fails: Cannot find module './remitoPdf.test.ts')

------
https://chatgpt.com/codex/tasks/task_e_68b74e0a1e7c832aa7031af706d72abe