### PR TITLE
feat: track volume and weight in position metrics

### DIFF
--- a/src/DALC/posiciones.dalc.ts
+++ b/src/DALC/posiciones.dalc.ts
@@ -474,6 +474,8 @@ export const posiciones_getHeatmap_DALC = async (
         .createQueryBuilder('pm')
         .select('pos.descripcion', 'nombre')
         .addSelect('SUM(pm.unidades)', 'valor')
+        .addSelect('SUM(pm.volumenMovidoCm3)', 'volumen')
+        .addSelect('SUM(pm.pesoMovidoKg)', 'peso')
         .innerJoin(Posicion, 'pos', 'pos.id = pm.posicionId')
         .where('pm.empresaId = :idEmpresa', { idEmpresa })
         .andWhere('pm.fecha >= :start AND pm.fecha < :end', { start, end })
@@ -490,6 +492,12 @@ export const posiciones_getHeatmap_DALC = async (
         const partes = (r.nombre || '').split('-')
         const x = parseInt(partes[1], 10)
         const y = parseInt(partes[2], 10)
-        return { x, y, valor: Number(r.valor) }
+        return {
+            x,
+            y,
+            valor: Number(r.valor),
+            volumen: Number(r.volumen),
+            peso: Number(r.peso),
+        }
     })
 }

--- a/src/DALC/productos.dalc.ts
+++ b/src/DALC/productos.dalc.ts
@@ -51,13 +51,17 @@ const registrarPosicionMetrica = async (
     idEmpresa: number,
     idPosicion: number,
     unidades: number,
-    accion: string
+    accion: string,
+    volumenMovido: number,
+    pesoMovido: number
 ) => {
     const metrica = getRepository(PosicionMetrica).create({
         IdEmpresa: idEmpresa,
         IdPosicion: idPosicion,
         Unidades: unidades,
         Accion: accion,
+        VolumenMovidoCm3: volumenMovido,
+        PesoMovidoKg: pesoMovido,
         Fecha: new Date()
     })
     await getRepository(PosicionMetrica).save(metrica)
@@ -136,7 +140,7 @@ export const producto_posicionar_DALC = async (
     const registroEntrada=getRepository(PosicionProducto).create(entradaAPosicion)
     const result=await getRepository(PosicionProducto).save(registroEntrada)
     if (result!=null) {
-        await registrarPosicionMetrica(idEmpresa, posicion.Id, unidadesAPosicionar, 'IN')
+        await registrarPosicionMetrica(idEmpresa, posicion.Id, unidadesAPosicionar, 'IN', ocupacion1.VolumenOcupadoCm3, ocupacion1.PesoOcupadoKg)
         return {status: "OK"}
     } else {
         return {status: "ERROR", error: result}
@@ -223,7 +227,7 @@ export const reposicionar_producto_excel_DALC = async (
 
             const registroEntrada=getRepository(PosicionProducto).create(entradaAPosicion)
             result=await getRepository(PosicionProducto).save(registroEntrada)
-            await registrarPosicionMetrica(producto.IdEmpresa, posicion.Id, unidadesAPosicionar, 'IN')
+            await registrarPosicionMetrica(producto.IdEmpresa, posicion.Id, unidadesAPosicionar, 'IN', ocupacion2.VolumenOcupadoCm3, ocupacion2.PesoOcupadoKg)
             //Puede que tenga una posicion existe en 1, pero sea distinta a la que vino entonces si eso pasa guardo en el historico.
             if(pos.IdPosicion!=posicion.Id){
                 const saveHistorico = await producto_SaveHistoricoDePosicion_DALC(producto.Id, producto.IdEmpresa, pos.IdPosicion, 1, loteNulo, usuario)
@@ -258,7 +262,7 @@ export const reposicionar_producto_excel_DALC = async (
 
         const registroEntrada=getRepository(PosicionProducto).create(entradaAPosicion)
         result=await getRepository(PosicionProducto).save(registroEntrada)
-        await registrarPosicionMetrica(producto.IdEmpresa, posicion.Id, unidadesAPosicionar, 'IN')
+        await registrarPosicionMetrica(producto.IdEmpresa, posicion.Id, unidadesAPosicionar, 'IN', ocupacion3.VolumenOcupadoCm3, ocupacion3.PesoOcupadoKg)
     }
 
   
@@ -330,7 +334,7 @@ export const reposicionar_partida_excel_DALC = async (partida: Partida, posicion
 
             const registroEntrada=getRepository(PosicionProducto).create(entradaAPosicion)
             result=await getRepository(PosicionProducto).save(registroEntrada)
-            await registrarPosicionMetrica(partida.IdEmpresa, posicion.Id, unidadesAPosicionar, 'IN')
+            await registrarPosicionMetrica(partida.IdEmpresa, posicion.Id, unidadesAPosicionar, 'IN', ocupacionPartida.VolumenOcupadoCm3, ocupacionPartida.PesoOcupadoKg)
             //Puede que tenga una posicion existe en 1, pero sea distinta a la que vino entonces si eso pasa guardo en el historico.
             if(idPosicion!=posicion.Id){
                 const saveHistorico = await producto_SaveHistoricoDePosicion_DALC(partida.Id, partida.IdEmpresa, idPosicion, 1, loteNulo, usuario)
@@ -365,7 +369,7 @@ export const reposicionar_partida_excel_DALC = async (partida: Partida, posicion
 
         const registroEntrada=getRepository(PosicionProducto).create(entradaAPosicion)
         result=await getRepository(PosicionProducto).save(registroEntrada)
-        await registrarPosicionMetrica(partida.IdEmpresa, posicion.Id, unidadesAPosicionar, 'IN')
+        await registrarPosicionMetrica(partida.IdEmpresa, posicion.Id, unidadesAPosicionar, 'IN', ocupacionPartida2.VolumenOcupadoCm3, ocupacionPartida2.PesoOcupadoKg)
     }
 
   
@@ -412,7 +416,7 @@ export const producto_desposicionar_DALC = async (producto: Producto, posicion: 
         }
 
         if (result!=null) {
-            await registrarPosicionMetrica(producto.IdEmpresa, posicion.Id, unidadesADesposicionar, 'OUT')
+            await registrarPosicionMetrica(producto.IdEmpresa, posicion.Id, unidadesADesposicionar, 'OUT', ocupacionSalida.VolumenOcupadoCm3, ocupacionSalida.PesoOcupadoKg)
             return {status: "OK"}
         } else {
             return {status: "ERROR", error: result}
@@ -448,7 +452,7 @@ export const producto_desposicionar_paqueteria_DALC = async (producto: number, p
     const result=await getRepository(PosicionProducto).save(registroSalida)
 
     if (result!=null) {
-        await registrarPosicionMetrica(idEmpresa, posicion, unidadesADesposicionar, 'OUT')
+        await registrarPosicionMetrica(idEmpresa, posicion, unidadesADesposicionar, 'OUT', ocupacionPaqueteria.VolumenOcupadoCm3, ocupacionPaqueteria.PesoOcupadoKg)
         return {status: "OK"}
     } else {
         return {status: "ERROR", error: result}
@@ -486,7 +490,7 @@ export const producto_desposicionar_Lote_DALC = async (posicion: number, unidade
     const result=await getRepository(PosicionProducto).save(registroSalida)
 
     if (result!=null) {
-        await registrarPosicionMetrica(idEmpresa, posicion, unidadesADesposicionar, 'OUT')
+        await registrarPosicionMetrica(idEmpresa, posicion, unidadesADesposicionar, 'OUT', ocupacionLote.VolumenOcupadoCm3, ocupacionLote.PesoOcupadoKg)
         return {status: "OK"}
     } else {
         return {status: "ERROR", error: result}
@@ -885,7 +889,7 @@ export const producto_moverDePosicion_DALC =  async (idProducto: number, idEmpre
     const registroSalida=getRepository(PosicionProducto).create(salidaDePosicion)
     let result=await getRepository(PosicionProducto).save(registroSalida)
     if (result!=null) {
-        await registrarPosicionMetrica(idEmpresa, idPosicionOrigen, cantidad, 'OUT')
+        await registrarPosicionMetrica(idEmpresa, idPosicionOrigen, cantidad, 'OUT', ocupacionMoverSalida.VolumenOcupadoCm3, ocupacionMoverSalida.PesoOcupadoKg)
         const entradaAPosicion=new PosicionProducto()
         entradaAPosicion.IdEmpresa=idEmpresa
         entradaAPosicion.IdPosicion=idPosicionDestino
@@ -903,7 +907,7 @@ export const producto_moverDePosicion_DALC =  async (idProducto: number, idEmpre
         result=await getRepository(PosicionProducto).save(registroEntrada)
 
         if (result!=null) {
-            await registrarPosicionMetrica(idEmpresa, idPosicionDestino, cantidad, 'IN')
+            await registrarPosicionMetrica(idEmpresa, idPosicionDestino, cantidad, 'IN', ocupacionMoverEntrada.VolumenOcupadoCm3, ocupacionMoverEntrada.PesoOcupadoKg)
             if(lote!=""){
                 const result=await getRepository(LoteDetalle).update({Lote: lote},{IdPosicion: idPosicionDestino})
             }

--- a/src/controllers/dashboard.controller.ts
+++ b/src/controllers/dashboard.controller.ts
@@ -38,14 +38,20 @@ export const getDashboard = async (req: Request, res: Response): Promise<Respons
         .createQueryBuilder('pm')
         .select('pm.posicionId', 'posicionId')
         .addSelect('SUM(pm.unidades)', 'mov')
+        .addSelect('SUM(pm.volumenMovidoCm3)', 'volumen')
+        .addSelect('SUM(pm.pesoMovidoKg)', 'peso')
         .where('pm.empresaId = :idEmpresa', { idEmpresa })
         .groupBy('pm.posicionId')
         .getRawMany();
     const rotacionPromedio = rotacionRows.reduce((a, r) => a + Number(r.mov), 0) / (rotacionRows.length || 1);
+    const volumenMovidoPromedio = rotacionRows.reduce((a, r) => a + Number(r.volumen), 0) / (rotacionRows.length || 1);
+    const pesoMovidoPromedio = rotacionRows.reduce((a, r) => a + Number(r.peso), 0) / (rotacionRows.length || 1);
 
     const data = {
         ocupacionPromedio: count ? totalPct / count : 0,
         rotacionPromedio,
+        volumenMovidoPromedio,
+        pesoMovidoPromedio,
         posicionesCriticas: criticas
     };
     return res.json(api.getFormatedResponse(data));

--- a/src/entities/PosicionMetrica.ts
+++ b/src/entities/PosicionMetrica.ts
@@ -17,6 +17,12 @@ export class PosicionMetrica {
     @Column()
     Accion: string
 
+    @Column({ name: "volumenMovidoCm3", type: "float", nullable: true })
+    VolumenMovidoCm3: number
+
+    @Column({ name: "pesoMovidoKg", type: "float", nullable: true })
+    PesoMovidoKg: number
+
     @Column({ type: "timestamp", default: () => "CURRENT_TIMESTAMP" })
     Fecha: Date
 }

--- a/src/migrations/177-add-volumen-peso-posicion-metricas.ts
+++ b/src/migrations/177-add-volumen-peso-posicion-metricas.ts
@@ -1,0 +1,28 @@
+import { MigrationInterface, QueryRunner, TableColumn } from "typeorm";
+
+export class AddVolumenPesoPosicionMetricas177 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.addColumn(
+            "posicion_metricas",
+            new TableColumn({
+                name: "volumenMovidoCm3",
+                type: "float",
+                isNullable: true,
+            })
+        );
+
+        await queryRunner.addColumn(
+            "posicion_metricas",
+            new TableColumn({
+                name: "pesoMovidoKg",
+                type: "float",
+                isNullable: true,
+            })
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropColumn("posicion_metricas", "pesoMovidoKg");
+        await queryRunner.dropColumn("posicion_metricas", "volumenMovidoCm3");
+    }
+}


### PR DESCRIPTION
## Summary
- add volume and weight fields to `PosicionMetrica` and create DB migration
- record moved volume and weight when registering position metrics
- include volume and weight in heatmap and dashboard calculations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run test:pdf` *(fails: Cannot find module './remitoPdf.test.ts')*
- `npm run build` *(fails: xcopy not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b74f28ae58832aad6f4c120adaca8b