### PR TITLE
feat: add pallet and pallet type management

### DIFF
--- a/src/DALC/palletTipos.dalc.ts
+++ b/src/DALC/palletTipos.dalc.ts
@@ -1,0 +1,32 @@
+import { getRepository } from "typeorm";
+import { PalletTipo } from "../entities/PalletTipo";
+
+export const palletTipos_getAll_DALC = async () => {
+    return await getRepository(PalletTipo).find();
+};
+
+export const palletTipo_getById_DALC = async (id: number) => {
+    return await getRepository(PalletTipo).findOne({ where: { Id: id } });
+};
+
+export const palletTipo_add_DALC = async (body: Partial<PalletTipo>) => {
+    const repo = getRepository(PalletTipo);
+    const nuevo = repo.create(body);
+    return await repo.save(nuevo);
+};
+
+export const palletTipo_edit_DALC = async (body: Partial<PalletTipo>, id: number) => {
+    const repo = getRepository(PalletTipo);
+    await repo.update(id, body);
+    return await repo.findOne({ where: { Id: id } });
+};
+
+export const palletTipo_deleteById_DALC = async (id: number) => {
+    await getRepository(PalletTipo)
+        .createQueryBuilder()
+        .delete()
+        .from("pallet_tipos")
+        .where("Id = :id", { id })
+        .execute();
+    return;
+};

--- a/src/DALC/pallets.dalc.ts
+++ b/src/DALC/pallets.dalc.ts
@@ -1,0 +1,57 @@
+import { getRepository } from "typeorm";
+import { Pallet } from "../entities/Pallet";
+import { PalletTipo } from "../entities/PalletTipo";
+
+export const pallets_getAll_DALC = async () => {
+    return await getRepository(Pallet).find({ relations: ["Tipo"] });
+};
+
+export const pallet_getById_DALC = async (id: number) => {
+    return await getRepository(Pallet).findOne(id, { relations: ["Tipo"] });
+};
+
+export const pallet_getByCodigo_DALC = async (codigo: string) => {
+    return await getRepository(Pallet).findOne({ where: { Codigo: codigo }, relations: ["Tipo"] });
+};
+
+export const pallet_add_DALC = async (body: Partial<Pallet>) => {
+    const repo = getRepository(Pallet);
+    const tipo = await getRepository(PalletTipo).findOne(body.PalletTipoId);
+    const nuevo = repo.create({
+        Codigo: body.Codigo,
+        PalletTipoId: body.PalletTipoId!,
+        PosicionId: body.PosicionId,
+        VolumenOcupadoCm3: body.VolumenOcupadoCm3 ?? 0,
+        PesoOcupadoKg: body.PesoOcupadoKg ?? 0,
+    });
+    nuevo.EspacioLibreVolumenCm3 = (tipo?.CapacidadVolumenCm3 ?? 0) - (nuevo.VolumenOcupadoCm3 ?? 0);
+    nuevo.EspacioLibrePesoKg = (tipo?.CapacidadPesoKg ?? 0) - (nuevo.PesoOcupadoKg ?? 0);
+    const saved = await repo.save(nuevo);
+    return await repo.findOne(saved.Id, { relations: ["Tipo"] });
+};
+
+export const pallet_edit_DALC = async (body: Partial<Pallet>, id: number) => {
+    const repo = getRepository(Pallet);
+    await repo.update(id, body);
+    const pallet = await repo.findOne(id, { relations: ["Tipo"] });
+    if (pallet) {
+        const tipo = await getRepository(PalletTipo).findOne(pallet.PalletTipoId);
+        pallet.EspacioLibreVolumenCm3 = (tipo?.CapacidadVolumenCm3 ?? 0) - (pallet.VolumenOcupadoCm3 ?? 0);
+        pallet.EspacioLibrePesoKg = (tipo?.CapacidadPesoKg ?? 0) - (pallet.PesoOcupadoKg ?? 0);
+        await repo.update(id, {
+            EspacioLibreVolumenCm3: pallet.EspacioLibreVolumenCm3,
+            EspacioLibrePesoKg: pallet.EspacioLibrePesoKg,
+        });
+    }
+    return pallet;
+};
+
+export const pallet_deleteById_DALC = async (id: number) => {
+    await getRepository(Pallet)
+        .createQueryBuilder()
+        .delete()
+        .from("pallets")
+        .where("Id = :id", { id })
+        .execute();
+    return;
+};

--- a/src/controllers/palletTipos.controller.ts
+++ b/src/controllers/palletTipos.controller.ts
@@ -1,0 +1,50 @@
+import { Request, Response } from "express";
+import {
+    palletTipos_getAll_DALC,
+    palletTipo_getById_DALC,
+    palletTipo_add_DALC,
+    palletTipo_edit_DALC,
+    palletTipo_deleteById_DALC
+} from "../DALC/palletTipos.dalc";
+
+export const getAll = async (req: Request, res: Response): Promise<Response> => {
+    const tipos = await palletTipos_getAll_DALC();
+    return res.json(require("lsi-util-node/API").getFormatedResponse(tipos));
+};
+
+export const getById = async (req: Request, res: Response): Promise<Response> => {
+    const tipo = await palletTipo_getById_DALC(parseInt(req.params.id));
+    if (tipo) {
+        return res.json(require("lsi-util-node/API").getFormatedResponse(tipo));
+    }
+    return res.status(404).json(require("lsi-util-node/API").getFormatedResponse("", "Tipo de pallet inexistente"));
+};
+
+export const create = async (req: Request, res: Response): Promise<Response> => {
+    const { CapacidadPesoKg, CapacidadVolumenCm3 } = req.body;
+    if (CapacidadPesoKg < 0 || CapacidadVolumenCm3 < 0) {
+        return res.status(400).json(require("lsi-util-node/API").getFormatedResponse("", "Capacidades inválidas"));
+    }
+    const result = await palletTipo_add_DALC(req.body);
+    return res.json(require("lsi-util-node/API").getFormatedResponse(result));
+};
+
+export const update = async (req: Request, res: Response): Promise<Response> => {
+    const id = parseInt(req.params.id);
+    const tipo = await palletTipo_getById_DALC(id);
+    if (!tipo) {
+        return res.status(404).json(require("lsi-util-node/API").getFormatedResponse("", "Tipo de pallet inexistente"));
+    }
+    const capacidadPeso = req.body.CapacidadPesoKg ?? tipo.CapacidadPesoKg;
+    const capacidadVolumen = req.body.CapacidadVolumenCm3 ?? tipo.CapacidadVolumenCm3;
+    if (capacidadPeso < 0 || capacidadVolumen < 0) {
+        return res.status(400).json(require("lsi-util-node/API").getFormatedResponse("", "Capacidades inválidas"));
+    }
+    const result = await palletTipo_edit_DALC(req.body, id);
+    return res.json(require("lsi-util-node/API").getFormatedResponse(result));
+};
+
+export const remove = async (req: Request, res: Response): Promise<Response> => {
+    await palletTipo_deleteById_DALC(parseInt(req.params.id));
+    return res.json(require("lsi-util-node/API").getFormatedResponse("OK"));
+};

--- a/src/controllers/pallets.controller.ts
+++ b/src/controllers/pallets.controller.ts
@@ -1,0 +1,60 @@
+import { Request, Response } from "express";
+import {
+    pallets_getAll_DALC,
+    pallet_getById_DALC,
+    pallet_add_DALC,
+    pallet_edit_DALC,
+    pallet_deleteById_DALC
+} from "../DALC/pallets.dalc";
+import { palletTipo_getById_DALC } from "../DALC/palletTipos.dalc";
+
+export const getAll = async (req: Request, res: Response): Promise<Response> => {
+    const pallets = await pallets_getAll_DALC();
+    return res.json(require("lsi-util-node/API").getFormatedResponse(pallets));
+};
+
+export const getById = async (req: Request, res: Response): Promise<Response> => {
+    const pallet = await pallet_getById_DALC(parseInt(req.params.id));
+    if (pallet) {
+        return res.json(require("lsi-util-node/API").getFormatedResponse(pallet));
+    }
+    return res.status(404).json(require("lsi-util-node/API").getFormatedResponse("", "Pallet inexistente"));
+};
+
+export const create = async (req: Request, res: Response): Promise<Response> => {
+    const { PalletTipoId, VolumenOcupadoCm3 = 0, PesoOcupadoKg = 0 } = req.body;
+    const tipo = await palletTipo_getById_DALC(PalletTipoId);
+    if (!tipo) {
+        return res.status(404).json(require("lsi-util-node/API").getFormatedResponse("", "Tipo de pallet inexistente"));
+    }
+    if (VolumenOcupadoCm3 > tipo.CapacidadVolumenCm3 || PesoOcupadoKg > tipo.CapacidadPesoKg) {
+        return res.status(400).json(require("lsi-util-node/API").getFormatedResponse("", "Capacidad excedida"));
+    }
+    const result = await pallet_add_DALC(req.body);
+    return res.json(require("lsi-util-node/API").getFormatedResponse(result));
+};
+
+export const update = async (req: Request, res: Response): Promise<Response> => {
+    const id = parseInt(req.params.id);
+    const pallet = await pallet_getById_DALC(id);
+    if (!pallet) {
+        return res.status(404).json(require("lsi-util-node/API").getFormatedResponse("", "Pallet inexistente"));
+    }
+    const palletTipoId = req.body.PalletTipoId ?? pallet.PalletTipoId;
+    const tipo = await palletTipo_getById_DALC(palletTipoId);
+    if (!tipo) {
+        return res.status(404).json(require("lsi-util-node/API").getFormatedResponse("", "Tipo de pallet inexistente"));
+    }
+    const volumen = req.body.VolumenOcupadoCm3 ?? pallet.VolumenOcupadoCm3;
+    const peso = req.body.PesoOcupadoKg ?? pallet.PesoOcupadoKg;
+    if (volumen > tipo.CapacidadVolumenCm3 || peso > tipo.CapacidadPesoKg) {
+        return res.status(400).json(require("lsi-util-node/API").getFormatedResponse("", "Capacidad excedida"));
+    }
+    const result = await pallet_edit_DALC(req.body, id);
+    return res.json(require("lsi-util-node/API").getFormatedResponse(result));
+};
+
+export const remove = async (req: Request, res: Response): Promise<Response> => {
+    await pallet_deleteById_DALC(parseInt(req.params.id));
+    return res.json(require("lsi-util-node/API").getFormatedResponse("OK"));
+};

--- a/src/controllers/productos.controller.ts
+++ b/src/controllers/productos.controller.ts
@@ -57,6 +57,7 @@ import {
 } from "../DALC/posiciones.dalc"
 import { Producto } from "../entities/Producto";
 import { Any } from "typeorm";
+import { pallet_getByCodigo_DALC, pallet_add_DALC } from "../DALC/pallets.dalc";
 
 
 
@@ -87,7 +88,18 @@ export const set_posicionar = async (req: Request, res: Response): Promise <Resp
         }
     }
 
-    const idPallet = req.body?.idPallet ? parseInt(req.body.idPallet) : undefined
+    let idPallet: number | undefined;
+    if (req.body?.idPallet) {
+        idPallet = parseInt(req.body.idPallet);
+    } else if (req.body?.palletCodigo && req.body?.palletTipoId) {
+        const codigo = req.body.palletCodigo;
+        const tipoId = parseInt(req.body.palletTipoId);
+        let pallet = await pallet_getByCodigo_DALC(codigo);
+        if (!pallet) {
+            pallet = await pallet_add_DALC({ Codigo: codigo, PalletTipoId: tipoId });
+        }
+        idPallet = pallet?.Id;
+    }
     const result=await producto_posicionar_DALC(producto!, posicion!, parseInt(req.params.cantidadAPosicionar),parseInt(req.params.idEmpresa), idPallet)
 
     if (result.status==="OK") {
@@ -134,7 +146,18 @@ export const set_posicionar_excel = async (req: Request, res: Response): Promise
     if (producto===null) {
         return res.status(404).json(require("lsi-util-node/API").getFormatedResponse("", "Producto inexistente"))
     }
-    const idPallet = req.body?.idPallet ? parseInt(req.body.idPallet) : undefined
+    let idPallet: number | undefined;
+    if (req.body?.idPallet) {
+        idPallet = parseInt(req.body.idPallet);
+    } else if (req.body?.palletCodigo && req.body?.palletTipoId) {
+        const codigo = req.body.palletCodigo;
+        const tipoId = parseInt(req.body.palletTipoId);
+        let pallet = await pallet_getByCodigo_DALC(codigo);
+        if (!pallet) {
+            pallet = await pallet_add_DALC({ Codigo: codigo, PalletTipoId: tipoId });
+        }
+        idPallet = pallet?.Id;
+    }
     const result=await reposicionar_producto_excel_DALC(producto!, posicion!, parseInt(req.params.cantidadAPosicionar),req.params.usuario, idPallet)
 
     if (result.status==="OK") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,8 @@ import emailProcesoConfigRoutes from './routes/emailProcesoConfig.routes';
 import reportesRoutes from './routes/reportes.routes';
 import zonasRoutes from './routes/zonas.routes';
 import dashboardRoutes from './routes/dashboard.routes';
+import palletTiposRoutes from './routes/palletTipos.routes';
+import palletsRoutes from './routes/pallets.routes';
 import { monitorService } from './services/monitor.service';
 
 import tiendaNubeRoutes from "./api/tiendanube/routes/tiendanube.routes";
@@ -78,6 +80,8 @@ app.use(guiasRendicionesRoutes)
 app.use(posicionesRoutes)
 app.use(productosRoutes)
 app.use(categoriasRoutes)
+app.use(palletTiposRoutes)
+app.use(palletsRoutes)
 app.use(posicionesProductosRoutes)
 app.use(ordenesRoutes)
 app.use(chofereRoutes)

--- a/src/routes/palletTipos.routes.ts
+++ b/src/routes/palletTipos.routes.ts
@@ -1,0 +1,13 @@
+import { Router } from "express";
+import { getAll, getById, create, update, remove } from "../controllers/palletTipos.controller";
+
+const router = Router();
+const prefixAPI = "/apiv3";
+
+router.get(prefixAPI + "/palletTipos", getAll);
+router.get(prefixAPI + "/palletTipos/:id", getById);
+router.post(prefixAPI + "/palletTipos", create);
+router.put(prefixAPI + "/palletTipos/:id", update);
+router.delete(prefixAPI + "/palletTipos/:id", remove);
+
+export default router;

--- a/src/routes/pallets.routes.ts
+++ b/src/routes/pallets.routes.ts
@@ -1,0 +1,13 @@
+import { Router } from "express";
+import { getAll, getById, create, update, remove } from "../controllers/pallets.controller";
+
+const router = Router();
+const prefixAPI = "/apiv3";
+
+router.get(prefixAPI + "/pallets", getAll);
+router.get(prefixAPI + "/pallets/:id", getById);
+router.post(prefixAPI + "/pallets", create);
+router.put(prefixAPI + "/pallets/:id", update);
+router.delete(prefixAPI + "/pallets/:id", remove);
+
+export default router;


### PR DESCRIPTION
## Summary
- add DALC modules for pallets and pallet types
- create controllers and routes with capacity validation
- allow product endpoints to create or link pallets

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b760753b34832aae5446c54eb872a0