### PR TITLE
feat: track total vs available capacity for positions

### DIFF
--- a/requests/posiciones.rest
+++ b/requests/posiciones.rest
@@ -29,8 +29,10 @@ Content-Type: application/json
 {
   "UsuarioInventario": "Leo Lob",
   "FechaInventario": "2021-07-01",
-  "CapacidadPesoKg": 1000,
-  "CapacidadVolumenCm3": 500000,
+  "CapacidadTotalPesoKg": 1000,
+  "CapacidadTotalVolumenCm3": 500000,
+  "PesoDisponibleKg": 1000,
+  "VolumenDisponibleCm3": 500000,
   "FactorDesperdicio": 0.1,
   "CategoriaPermitidaId": 1
 }

--- a/src/DALC/posiciones.dalc.ts
+++ b/src/DALC/posiciones.dalc.ts
@@ -15,8 +15,10 @@ export const posicion_add = async (
   ) => {
     const resultToSave = getRepository(Posicion).create({
         Nombre: nombre,
-        CapacidadPesoKg: capacidadPeso,
-        CapacidadVolumenCm3: capacidadVolumen,
+        CapacidadTotalPesoKg: capacidadPeso,
+        CapacidadTotalVolumenCm3: capacidadVolumen,
+        PesoDisponibleKg: capacidadPeso,
+        VolumenDisponibleCm3: capacidadVolumen,
         FactorDesperdicio: factorDesperdicio,
         CategoriaPermitidaId: categoriaPermitidaId
     })

--- a/src/DALC/productos.dalc.ts
+++ b/src/DALC/productos.dalc.ts
@@ -36,14 +36,14 @@ const calcularOcupacion = (producto: Producto | undefined, unidades: number, fac
 }
 
 const actualizarCapacidad = async (posicion: Posicion, deltaVolumen: number, deltaPeso: number) => {
-    const nuevaCapacidadVolumen = (posicion.CapacidadVolumenCm3 ?? 0) + deltaVolumen
-    const nuevaCapacidadPeso = (posicion.CapacidadPesoKg ?? 0) + deltaPeso
+    const nuevaCapacidadVolumen = (posicion.VolumenDisponibleCm3 ?? 0) + deltaVolumen
+    const nuevaCapacidadPeso = (posicion.PesoDisponibleKg ?? 0) + deltaPeso
     await getRepository(Posicion).update(posicion.Id, {
-        CapacidadVolumenCm3: nuevaCapacidadVolumen,
-        CapacidadPesoKg: nuevaCapacidadPeso,
+        VolumenDisponibleCm3: nuevaCapacidadVolumen,
+        PesoDisponibleKg: nuevaCapacidadPeso,
     })
-    posicion.CapacidadVolumenCm3 = nuevaCapacidadVolumen
-    posicion.CapacidadPesoKg = nuevaCapacidadPeso
+    posicion.VolumenDisponibleCm3 = nuevaCapacidadVolumen
+    posicion.PesoDisponibleKg = nuevaCapacidadPeso
     return posicion
 }
 
@@ -105,7 +105,7 @@ export const producto_posicionar_DALC = async (
         return {status: "ERROR", error: "Categoría no permitida en la posición"}
     }
 
-    if (posicionActual && ((posicionActual.CapacidadVolumenCm3 ?? 0) < ocupacion1.VolumenOcupadoCm3 || (posicionActual.CapacidadPesoKg ?? 0) < ocupacion1.PesoOcupadoKg)) {
+    if (posicionActual && ((posicionActual.VolumenDisponibleCm3 ?? 0) < ocupacion1.VolumenOcupadoCm3 || (posicionActual.PesoDisponibleKg ?? 0) < ocupacion1.PesoOcupadoKg)) {
         return {status: "ERROR", error: "Capacidad insuficiente en la posición"}
     }
 
@@ -194,7 +194,7 @@ export const reposicionar_producto_excel_DALC = async (
             if (posicionActual?.CategoriaPermitidaId && producto.CategoriaId !== posicionActual.CategoriaPermitidaId) {
                 return {status: "ERROR", error: "Categoría no permitida en la posición"}
             }
-            if (posicionActual && ((posicionActual.CapacidadVolumenCm3 ?? 0) < ocupacion2.VolumenOcupadoCm3 || (posicionActual.CapacidadPesoKg ?? 0) < ocupacion2.PesoOcupadoKg)) {
+            if (posicionActual && ((posicionActual.VolumenDisponibleCm3 ?? 0) < ocupacion2.VolumenOcupadoCm3 || (posicionActual.PesoDisponibleKg ?? 0) < ocupacion2.PesoOcupadoKg)) {
                 return {status: "ERROR", error: "Capacidad insuficiente en la posición"}
             }
             if (posicionActual) {
@@ -243,7 +243,7 @@ export const reposicionar_producto_excel_DALC = async (
         if (posicionActual?.CategoriaPermitidaId && producto.CategoriaId !== posicionActual.CategoriaPermitidaId) {
             return {status: "ERROR", error: "Categoría no permitida en la posición"}
         }
-        if (posicionActual && ((posicionActual.CapacidadVolumenCm3 ?? 0) < ocupacion3.VolumenOcupadoCm3 || (posicionActual.CapacidadPesoKg ?? 0) < ocupacion3.PesoOcupadoKg)) {
+        if (posicionActual && ((posicionActual.VolumenDisponibleCm3 ?? 0) < ocupacion3.VolumenOcupadoCm3 || (posicionActual.PesoDisponibleKg ?? 0) < ocupacion3.PesoOcupadoKg)) {
             return {status: "ERROR", error: "Capacidad insuficiente en la posición"}
         }
         if (posicionActual) {
@@ -315,7 +315,7 @@ export const reposicionar_partida_excel_DALC = async (partida: Partida, posicion
             if (posicionActual?.CategoriaPermitidaId && productoInfo?.CategoriaId !== posicionActual.CategoriaPermitidaId) {
                 return {status: "ERROR", error: "Categoría no permitida en la posición"}
             }
-            if (posicionActual && ((posicionActual.CapacidadVolumenCm3 ?? 0) < ocupacionPartida.VolumenOcupadoCm3 || (posicionActual.CapacidadPesoKg ?? 0) < ocupacionPartida.PesoOcupadoKg)) {
+            if (posicionActual && ((posicionActual.VolumenDisponibleCm3 ?? 0) < ocupacionPartida.VolumenOcupadoCm3 || (posicionActual.PesoDisponibleKg ?? 0) < ocupacionPartida.PesoOcupadoKg)) {
                 return {status: "ERROR", error: "Capacidad insuficiente en la posición"}
             }
             if (posicionActual) {
@@ -350,7 +350,7 @@ export const reposicionar_partida_excel_DALC = async (partida: Partida, posicion
         if (posicionActual?.CategoriaPermitidaId && productoInfo?.CategoriaId !== posicionActual.CategoriaPermitidaId) {
             return {status: "ERROR", error: "Categoría no permitida en la posición"}
         }
-        if (posicionActual && ((posicionActual.CapacidadVolumenCm3 ?? 0) < ocupacionPartida2.VolumenOcupadoCm3 || (posicionActual.CapacidadPesoKg ?? 0) < ocupacionPartida2.PesoOcupadoKg)) {
+        if (posicionActual && ((posicionActual.VolumenDisponibleCm3 ?? 0) < ocupacionPartida2.VolumenOcupadoCm3 || (posicionActual.PesoDisponibleKg ?? 0) < ocupacionPartida2.PesoOcupadoKg)) {
             return {status: "ERROR", error: "Capacidad insuficiente en la posición"}
         }
         if (posicionActual) {
@@ -566,7 +566,7 @@ export const actualizar_unidades_loteDetalle_DALC = async (body: any)=>{
 
     })
     const ocupacionLoteDetalle = calcularOcupacion(productoInfo, body.unidades, factor)
-    if (posicionActual && ((posicionActual.CapacidadVolumenCm3 ?? 0) < ocupacionLoteDetalle.VolumenOcupadoCm3 || (posicionActual.CapacidadPesoKg ?? 0) < ocupacionLoteDetalle.PesoOcupadoKg)) {
+    if (posicionActual && ((posicionActual.VolumenDisponibleCm3 ?? 0) < ocupacionLoteDetalle.VolumenOcupadoCm3 || (posicionActual.PesoDisponibleKg ?? 0) < ocupacionLoteDetalle.PesoOcupadoKg)) {
         return {status: "ERROR", error: "Capacidad insuficiente en la posición"}
     }
     if (posicionActual) {
@@ -731,7 +731,7 @@ export const putLote_ByBarcodeAndEmpresa_DALC = async (barcode: string, idEmpres
                         const posicionActual = await posicion_getById_DALC(unResultado.IdPosicion)
                         const factor = obtenerFactor(posicionActual)
                         const ocupacionPutLote = calcularOcupacion(productoInfo, unResultado.Unidades, factor)
-                        if (posicionActual && ((posicionActual.CapacidadVolumenCm3 ?? 0) < ocupacionPutLote.VolumenOcupadoCm3 || (posicionActual.CapacidadPesoKg ?? 0) < ocupacionPutLote.PesoOcupadoKg)) {
+                        if (posicionActual && ((posicionActual.VolumenDisponibleCm3 ?? 0) < ocupacionPutLote.VolumenOcupadoCm3 || (posicionActual.PesoDisponibleKg ?? 0) < ocupacionPutLote.PesoOcupadoKg)) {
                             ingresoError.push(unResultado)
                             response.push({status: "ERROR", data: ingresoError, mensaje: "Capacidad insuficiente"})
                             continue
@@ -806,7 +806,7 @@ export const putLote_ByBarcodeAndEmpresa_DALC = async (barcode: string, idEmpres
                     const posicionActual = await posicion_getById_DALC(unResultado.idPosicion)
                     const factor = obtenerFactor(posicionActual)
                     const ocupacionPutLote2 = calcularOcupacion(productoInfo, unResultado.unidades, factor)
-                    if (posicionActual && ((posicionActual.CapacidadVolumenCm3 ?? 0) < ocupacionPutLote2.VolumenOcupadoCm3 || (posicionActual.CapacidadPesoKg ?? 0) < ocupacionPutLote2.PesoOcupadoKg)) {
+                    if (posicionActual && ((posicionActual.VolumenDisponibleCm3 ?? 0) < ocupacionPutLote2.VolumenOcupadoCm3 || (posicionActual.PesoDisponibleKg ?? 0) < ocupacionPutLote2.PesoOcupadoKg)) {
                         response.push({status: "ERROR", data: unResultado, mensaje: "Capacidad insuficiente"})
                         continue
                     }
@@ -862,7 +862,7 @@ export const producto_moverDePosicion_DALC =  async (idProducto: number, idEmpre
         return {status: "ERROR", error: "Categoría no permitida en la posición destino"}
     }
 
-    if (posDestino && ((posDestino.CapacidadVolumenCm3 ?? 0) < ocupacionMoverEntrada.VolumenOcupadoCm3 || (posDestino.CapacidadPesoKg ?? 0) < ocupacionMoverEntrada.PesoOcupadoKg)) {
+    if (posDestino && ((posDestino.VolumenDisponibleCm3 ?? 0) < ocupacionMoverEntrada.VolumenOcupadoCm3 || (posDestino.PesoDisponibleKg ?? 0) < ocupacionMoverEntrada.PesoOcupadoKg)) {
         return {status: "ERROR", error: "Capacidad insuficiente en la posición destino"}
     }
 
@@ -1434,7 +1434,7 @@ export const update_productosPosicionByLoteAndIdPosicion = async(boxNumber: stri
                     const factorDestino = obtenerFactor(posDestino)
                     const ocupacionQuitar = calcularOcupacion(productoInfo, parseInt(total), factorOrigen)
                     const ocupacionEntrada = calcularOcupacion(productoInfo, parseInt(total), factorDestino)
-                    if (posDestino && ((posDestino.CapacidadVolumenCm3 ?? 0) < ocupacionEntrada.VolumenOcupadoCm3 || (posDestino.CapacidadPesoKg ?? 0) < ocupacionEntrada.PesoOcupadoKg)) {
+                    if (posDestino && ((posDestino.VolumenDisponibleCm3 ?? 0) < ocupacionEntrada.VolumenOcupadoCm3 || (posDestino.PesoDisponibleKg ?? 0) < ocupacionEntrada.PesoOcupadoKg)) {
                         posicionesNuevas.push({lote: cadaLote.Lote,unidades: "", IdProducto: cadaLote.IdProducto, status:"ERROR",posicion: " ",mensaje:"Capacidad insuficiente"})
                         continue
                     }

--- a/src/controllers/dashboard.controller.ts
+++ b/src/controllers/dashboard.controller.ts
@@ -25,10 +25,10 @@ export const getDashboard = async (req: Request, res: Response): Promise<Respons
 
     for (const pos of posiciones) {
         const ocup = await posicion_getOcupacion_DALC(pos.Id, { idEmpresa, zona });
-        const pct = pos.CapacidadVolumenCm3 ? ocup.VolumenOcupadoCm3 / pos.CapacidadVolumenCm3 : 0;
+        const pct = pos.CapacidadTotalVolumenCm3 ? ocup.VolumenOcupadoCm3 / pos.CapacidadTotalVolumenCm3 : 0;
         totalPct += pct;
         count++;
-        const pctPeso = pos.CapacidadPesoKg ? ocup.PesoOcupadoKg / pos.CapacidadPesoKg : 0;
+        const pctPeso = pos.CapacidadTotalPesoKg ? ocup.PesoOcupadoKg / pos.CapacidadTotalPesoKg : 0;
         if ((umbralOcup && pct > umbralOcup) || (umbralPeso && pctPeso > umbralPeso)) {
             criticas.push({ Id: pos.Id, Nombre: pos.Nombre, Ocupacion: pct });
         }
@@ -49,6 +49,7 @@ export const getDashboard = async (req: Request, res: Response): Promise<Respons
 
     const data = {
         ocupacionPromedio: count ? totalPct / count : 0,
+        ocupacionLibrePromedio: count ? 1 - totalPct / count : 0,
         rotacionPromedio,
         volumenMovidoPromedio,
         pesoMovidoPromedio,

--- a/src/entities/Posicion.ts
+++ b/src/entities/Posicion.ts
@@ -17,11 +17,17 @@ export class Posicion {
     @Column({name: "usuario_inventario"})
     UsuarioInventario: string
 
-    @Column({name: "capacidad_peso_kg", type: "float", nullable: true})
-    CapacidadPesoKg: number
+    @Column({name: "capacidad_total_peso_kg", type: "float", nullable: true})
+    CapacidadTotalPesoKg: number
 
-    @Column({name: "capacidad_volumen_cm3", type: "float", nullable: true})
-    CapacidadVolumenCm3: number
+    @Column({name: "capacidad_total_volumen_cm3", type: "float", nullable: true})
+    CapacidadTotalVolumenCm3: number
+
+    @Column({name: "peso_disponible_kg", type: "float", nullable: true})
+    PesoDisponibleKg: number
+
+    @Column({name: "volumen_disponible_cm3", type: "float", nullable: true})
+    VolumenDisponibleCm3: number
 
     @Column({name: "factor_desperdicio", type: "float", nullable: true})
     FactorDesperdicio: number

--- a/src/migrations/178-add-total-capacity-posiciones.ts
+++ b/src/migrations/178-add-total-capacity-posiciones.ts
@@ -1,0 +1,33 @@
+import { MigrationInterface, QueryRunner, TableColumn } from "typeorm";
+
+export class AddTotalCapacityPosiciones178 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.renameColumn("posiciones", "capacidad_peso_kg", "peso_disponible_kg");
+        await queryRunner.renameColumn("posiciones", "capacidad_volumen_cm3", "volumen_disponible_cm3");
+
+        await queryRunner.addColumn(
+            "posiciones",
+            new TableColumn({
+                name: "capacidad_total_peso_kg",
+                type: "float",
+                isNullable: true,
+            })
+        );
+
+        await queryRunner.addColumn(
+            "posiciones",
+            new TableColumn({
+                name: "capacidad_total_volumen_cm3",
+                type: "float",
+                isNullable: true,
+            })
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropColumn("posiciones", "capacidad_total_volumen_cm3");
+        await queryRunner.dropColumn("posiciones", "capacidad_total_peso_kg");
+        await queryRunner.renameColumn("posiciones", "volumen_disponible_cm3", "capacidad_volumen_cm3");
+        await queryRunner.renameColumn("posiciones", "peso_disponible_kg", "capacidad_peso_kg");
+    }
+}

--- a/src/services/monitor.service.ts
+++ b/src/services/monitor.service.ts
@@ -25,8 +25,8 @@ export class MonitorService {
         const posiciones = await getRepository(Posicion).find();
         for (const pos of posiciones) {
             const ocupacion = await posicion_getOcupacion_DALC(pos.Id, { idEmpresa: cfg.IdEmpresa });
-            const pctVol = pos.CapacidadVolumenCm3 ? ocupacion.VolumenOcupadoCm3 / pos.CapacidadVolumenCm3 : 0;
-            const pctPeso = pos.CapacidadPesoKg ? ocupacion.PesoOcupadoKg / pos.CapacidadPesoKg : 0;
+            const pctVol = pos.CapacidadTotalVolumenCm3 ? ocupacion.VolumenOcupadoCm3 / pos.CapacidadTotalVolumenCm3 : 0;
+            const pctPeso = pos.CapacidadTotalPesoKg ? ocupacion.PesoOcupadoKg / pos.CapacidadTotalPesoKg : 0;
 
             if (
                 (cfg.UmbralOcupacion && pctVol > cfg.UmbralOcupacion) ||


### PR DESCRIPTION
## Summary
- add total and available capacity fields to positions
- update DALC logic and controllers to handle available capacity and percentages
- add migration for renamed and new capacity columns

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run test:pdf` *(fails: Cannot find module './remitoPdf.test.ts')*

------
https://chatgpt.com/codex/tasks/task_e_68b763efd9ec832aa1a1f08e387bd225