### PR TITLE
feat: add explicit coordinates for positions

### DIFF
--- a/requests/posiciones.rest
+++ b/requests/posiciones.rest
@@ -10,8 +10,17 @@ GET {{pathUrl}}/posiciones/conPosicionadoNegativo
 Authorization: {{credenciales}}
 
 ### Crea una posicion nueva
-POST {{pathUrl}}/posiciones/newOne/P-03
+POST {{pathUrl}}/posiciones/newOne
 Authorization: {{credenciales}}
+Content-Type: application/json
+
+{
+  "nombre": "P-03",
+  "coordX": 1,
+  "coordY": 1,
+  "capacidadPeso": 1000,
+  "capacidadVolumen": 500000
+}
 
 ### Eliminar una posicion
 DELETE {{pathUrl}}/posicion/deleteOneById/3729
@@ -33,7 +42,9 @@ Content-Type: application/json
   "CapacidadTotalVolumenCm3": 500000,
   "PesoDisponibleKg": 1000,
   "VolumenDisponibleCm3": 500000,
-  "FactorDesperdicio": 0.1,
-  "CategoriaPermitidaId": 1
+"FactorDesperdicio": 0.1,
+  "CategoriaPermitidaId": 1,
+  "coordX": 1,
+  "coordY": 2
 }
 

--- a/src/DALC/posiciones.dalc.ts
+++ b/src/DALC/posiciones.dalc.ts
@@ -11,7 +11,9 @@ export const posicion_add = async (
     capacidadPeso?: number,
     capacidadVolumen?: number,
     factorDesperdicio?: number,
-    categoriaPermitidaId?: number
+    categoriaPermitidaId?: number,
+    coordX?: number,
+    coordY?: number
   ) => {
     const resultToSave = getRepository(Posicion).create({
         Nombre: nombre,
@@ -20,7 +22,9 @@ export const posicion_add = async (
         PesoDisponibleKg: capacidadPeso,
         VolumenDisponibleCm3: capacidadVolumen,
         FactorDesperdicio: factorDesperdicio,
-        CategoriaPermitidaId: categoriaPermitidaId
+        CategoriaPermitidaId: categoriaPermitidaId,
+        CoordX: coordX,
+        CoordY: coordY
     })
     try {
         const result = await getRepository(Posicion).save(resultToSave)
@@ -474,7 +478,8 @@ export const posiciones_getHeatmap_DALC = async (
 
     const qb = getRepository(PosicionMetrica)
         .createQueryBuilder('pm')
-        .select('pos.descripcion', 'nombre')
+        .select('pos.coord_x', 'x')
+        .addSelect('pos.coord_y', 'y')
         .addSelect('SUM(pm.unidades)', 'valor')
         .addSelect('SUM(pm.volumenMovidoCm3)', 'volumen')
         .addSelect('SUM(pm.pesoMovidoKg)', 'peso')
@@ -490,16 +495,11 @@ export const posiciones_getHeatmap_DALC = async (
 
     const rows = await qb.groupBy('pm.posicionId').getRawMany()
 
-    return rows.map(r => {
-        const partes = (r.nombre || '').split('-')
-        const x = parseInt(partes[1], 10)
-        const y = parseInt(partes[2], 10)
-        return {
-            x,
-            y,
-            valor: Number(r.valor),
-            volumen: Number(r.volumen),
-            peso: Number(r.peso),
-        }
-    })
+    return rows.map(r => ({
+        x: Number(r.x),
+        y: Number(r.y),
+        valor: Number(r.valor),
+        volumen: Number(r.volumen),
+        peso: Number(r.peso),
+    }))
 }

--- a/src/controllers/posiciones.controller.ts
+++ b/src/controllers/posiciones.controller.ts
@@ -39,11 +39,15 @@ export const getPosicionesConPosicionadoNegativo = async (req: Request, res: Res
 }
 
 export const setPosicion = async (req: Request, res: Response): Promise<Response> => {
-    const { capacidadPeso, capacidadVolumen, factorDesperdicio, categoriaPermitidaId } = req.body
+    const { capacidadPeso, capacidadVolumen, factorDesperdicio, categoriaPermitidaId, coordX, coordY } = req.body
     const api = require("lsi-util-node/API")
 
     if ([capacidadPeso, capacidadVolumen, factorDesperdicio].some((v: number) => v !== undefined && v < 0)) {
         return res.status(400).json(api.getFormatedResponse("", "Los valores no pueden ser negativos"))
+    }
+
+    if ([coordX, coordY].some((v: number) => v !== undefined && (isNaN(v) || v < 0 || v > 999))) {
+        return res.status(400).json(api.getFormatedResponse("", "Coordenadas fuera de rango"))
     }
 
     if (categoriaPermitidaId !== undefined) {
@@ -66,6 +70,8 @@ export const setPosicion = async (req: Request, res: Response): Promise<Response
     }
     if (factorDesperdicio !== undefined) { body.FactorDesperdicio = factorDesperdicio; delete body.factorDesperdicio }
     if (categoriaPermitidaId !== undefined) { body.CategoriaPermitidaId = categoriaPermitidaId; delete body.categoriaPermitidaId }
+    if (coordX !== undefined) { body.CoordX = coordX; delete body.coordX }
+    if (coordY !== undefined) { body.CoordY = coordY; delete body.coordY }
 
     const result = await posicion_modify(parseInt(req.params.id), body)
     if (result!=null) {
@@ -76,7 +82,7 @@ export const setPosicion = async (req: Request, res: Response): Promise<Response
 }
 
 export const newPosicion = async (req: Request, res: Response): Promise<Response> => {
-    const { nombre, capacidadPeso, capacidadVolumen, factorDesperdicio, categoriaPermitidaId } = req.body
+    const { nombre, capacidadPeso, capacidadVolumen, factorDesperdicio, categoriaPermitidaId, coordX, coordY } = req.body
     const api = require("lsi-util-node/API")
 
     if (!nombre) {
@@ -87,6 +93,10 @@ export const newPosicion = async (req: Request, res: Response): Promise<Response
         return res.status(400).json(api.getFormatedResponse("", "Los valores no pueden ser negativos"))
     }
 
+    if ([coordX, coordY].some((v: number) => v === undefined || isNaN(v) || v < 0 || v > 999)) {
+        return res.status(400).json(api.getFormatedResponse("", "Coordenadas fuera de rango"))
+    }
+
     if (categoriaPermitidaId !== undefined) {
         const categoria = await getConnection().query("SELECT Id FROM categorias WHERE Id = ?", [categoriaPermitidaId])
         if (categoria.length === 0) {
@@ -94,7 +104,7 @@ export const newPosicion = async (req: Request, res: Response): Promise<Response
         }
     }
 
-    const result = await posicion_add(nombre, capacidadPeso, capacidadVolumen, factorDesperdicio, categoriaPermitidaId)
+    const result = await posicion_add(nombre, capacidadPeso, capacidadVolumen, factorDesperdicio, categoriaPermitidaId, coordX, coordY)
     if (result.status) {
         return res.json(api.getFormatedResponse(result.detalle))
     } else {

--- a/src/entities/Posicion.ts
+++ b/src/entities/Posicion.ts
@@ -35,6 +35,12 @@ export class Posicion {
     @Column({name: "categoria_permitida_id", type: "int", nullable: true})
     CategoriaPermitidaId: number
 
+    @Column({name: "coord_x", type: "int", nullable: true})
+    CoordX: number
+
+    @Column({name: "coord_y", type: "int", nullable: true})
+    CoordY: number
+
     @ManyToOne(() => Categoria, categoria => categoria.Posiciones, {nullable: true})
     @JoinColumn({name: "categoria_permitida_id"})
     CategoriaPermitida?: Categoria

--- a/src/migrations/177-add-coordinates-posiciones.ts
+++ b/src/migrations/177-add-coordinates-posiciones.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner, TableColumn } from "typeorm";
+
+export class AddCoordinatesPosiciones177 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.addColumn(
+            "posiciones",
+            new TableColumn({
+                name: "coord_x",
+                type: "int",
+                isNullable: true,
+            })
+        );
+        await queryRunner.addColumn(
+            "posiciones",
+            new TableColumn({
+                name: "coord_y",
+                type: "int",
+                isNullable: true,
+            })
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropColumn("posiciones", "coord_y");
+        await queryRunner.dropColumn("posiciones", "coord_x");
+    }
+}


### PR DESCRIPTION
## Summary
- add CoordX and CoordY columns to Posicion with migration
- accept and validate coordinates in position creation and updates
- compute heatmap using stored coordinates instead of parsing names

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: xcopy: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b765ad79ec832a9f24eabf510d09f7