### PR TITLE
feat: add occupancy summary endpoint

### DIFF
--- a/src/routes/posiciones.routes.ts
+++ b/src/routes/posiciones.routes.ts
@@ -25,6 +25,7 @@ import {
     getPosicionesConDetalleByEmpresa,
     getAllByEmpresaConProductos,
     getOcupacionById,
+    getOcupacionResumen,
     getHeatmap
 } from "../controllers/posiciones.controller"
 
@@ -36,6 +37,7 @@ router.get(prefixAPI+"/posiciones/byNombre/:nombre", getPosicionesPorNombre)
 router.get(prefixAPI+"/posiciones/byId/:id", getByID)
 router.put(prefixAPI+"/posiciones/vaciar/:id", vaciarPosicion)
 router.get(prefixAPI+"/posiciones/getContentById/:id", getContentByID)
+router.get(prefixAPI+"/posiciones/ocupacion", getOcupacionResumen)
 router.get(prefixAPI+"/posiciones/:id/ocupacion", getOcupacionById)
 router.get(prefixAPI+"/posiciones/getAllPosicionesByIdEmpresa/:idEmpresa", getAllPosicionesByIdEmpresa)
 router.get(prefixAPI+"/posiciones/heatmap", getHeatmap)


### PR DESCRIPTION
## Summary
- add DALC function to summarize position occupancy by company and zone
- expose GET /apiv3/posiciones/ocupacion with optional empresa and zona filters
- calculate percentage of used capacity in summary results

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: xcopy not found)*
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68b76b23cf60832aaad99ae0a6b4a772